### PR TITLE
Format of log message and printf-like methods (not ~F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # go-logger
 
 [![Build Status](https://travis-ci.org/apsdehal/go-logger.svg?branch=master)](https://travis-ci.org/apsdehal/go-logger)
@@ -5,11 +6,52 @@
 
 A simple go logger for easy logging and debugging of your programs
 
+# Preview
+[![Example Output](examples/example.png)](examples/example.go)
+
+# Formatting
+By default all log messages have format that you can see above (on pic).
+But you can override the default format and set format that you want.
+
+You can do it for Logger instance (after creating logger) ...
+```go
+log, _ := logger.New("pkgname", 1)
+log.SetFormat(format)
+```
+... or for package
+```go
+logger.SetDefaultFormat(format)
+```
+If you do it for package, all existing loggers will print log messages with format that these used already.
+But all newest loggers (which will be created after changing format for package) will use your specified format.
+
+But anyway after this, you can still set format of message for specific Logger instance.
+
+Format of log message must contains verbs that represent some info about current log entry.
+Ofc, format can contain not only verbs but also something else (for example text, digits, symbols, etc)
+
+### Format verbs:
+You can use the following verbs:
+```
+%{id}           - means number of current log message
+%{module}       - means module name (that you passed to func New())
+%{time}			- means current time in format "2006-01-02 15:04:05"
+%{time:format}	- means current time in format that you want
+					(supports all formats supported by go package "time")
+%{level}		- means level name (upper case) of log message ("ERROR", "DEBUG", etc)
+%{lvl}			- means first 3 letters of level name (upper case) of log message ("ERR", "DEB", etc)
+%{file} 		- means name of file in what you wanna write log
+%{filename}		- means the same as %{file}
+%{line}			- means line number of file in what you wanna write log
+%{message}		- means your log message
+```
+Non-existent verbs (like ```%{nonex-verb}``` or ```%{}```) will be replaced by an empty string.
+Invalid verbs (like ```%{inv-verb```) will be treated as plain text.
+
 # Example
 
 Example [program](examples/example.go) demonstrates how to use the logger.
 
-[![Example Output](examples/example.png)](examples/example.go)
 
 ```go
 package main
@@ -20,8 +62,8 @@ import (
 )
 
 func main () {
-	// Get the instance for logger class, "test" is the module name, 1 is used to 
-	// state if we want coloring 
+	// Get the instance for logger class, "test" is the module name, 1 is used to
+	// state if we want coloring
 	// Third option is optional and is instance of type io.Writer, defaults to os.Stderr
 	log, err := logger.New("test", 1, os.Stdout)
 	if err != nil {
@@ -48,6 +90,14 @@ func main () {
 	log.InfoF("This is %s!", "Info")
 
 	log.StackAsError("Message before printing stack");
+
+	// Show warning with format
+	log.SetFormat("[%{module}] [%{level}] %{message}")
+	log.Warning("This is Warning!") // output: "[test] [WARNING] This is Warning!"
+	// Also you can set your format as default format for all new loggers
+	logger.SetDefaultFormat("%{message}")
+	log2, _ := logger.New("pkg", 1, os.Stdout)
+	log2.Error("This is Error!") // output: "This is Error!"
 }
 ```
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -25,4 +25,24 @@ func main () {
 	log.Notice("This is Notice!")
 	// Show the info
 	log.Info("This is Info!")
+
+	// Show warning with format message
+	// Verbs:
+	// %{id} - number of msg
+	// %{time} - time with format 2006-01-02 15:04:05
+	//		%{time:format} - time with specified format
+	// %{module} - module name
+	// %{file} or %{filename} - filename
+	// %{line} - line number in file
+	// %{level} or %{lvl} - log level
+	//		%{lvl} - print only 3 first letters of log level
+	//		for example: DEB, WAR, etc
+	//		%{level} - print full name of log level
+	//	%{message} - log message
+	log.SetFormat("[%{module}] [%{level}] %{message}")
+	log.Warning("This is Warning!")
+	// Also you can set your format as default format for all new loggers
+	logger.SetDefaultFormat("%{message}")
+	log2, _ := logger.New("pkg", 1, os.Stdout)
+	log2.Error("This is Error!")
 }

--- a/examples/example.go
+++ b/examples/example.go
@@ -27,18 +27,6 @@ func main () {
 	log.Info("This is Info!")
 
 	// Show warning with format message
-	// Verbs:
-	// %{id} - number of msg
-	// %{time} - time with format 2006-01-02 15:04:05
-	//		%{time:format} - time with specified format
-	// %{module} - module name
-	// %{file} or %{filename} - filename
-	// %{line} - line number in file
-	// %{level} or %{lvl} - log level
-	//		%{lvl} - print only 3 first letters of log level
-	//		for example: DEB, WAR, etc
-	//		%{level} - print full name of log level
-	//	%{message} - log message
 	log.SetFormat("[%{module}] [%{level}] %{message}")
 	log.Warning("This is Warning!")
 	// Also you can set your format as default format for all new loggers

--- a/logger.go
+++ b/logger.go
@@ -303,7 +303,8 @@ func (l *Logger) PanicF(format string, a ...interface{}) {
 
 // PanicF is just like func l.CriticalF except that it is followed by a call to panic
 func (l *Logger) Panicf(format string, a ...interface{}) {
-	l.PanicF(format, a...)
+	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	panic(fmt.Sprintf(format, a...))
 }
 
 // Critical logs a message at a Critical Level
@@ -318,7 +319,7 @@ func (l *Logger) CriticalF(format string, a ...interface{}) {
 
 // CriticalF logs a message at Critical level using the same syntax and options as fmt.Printf
 func (l *Logger) Criticalf(format string, a ...interface{}) {
-	l.CriticalF(format, a...)
+	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
 }
 
 // Error logs a message at Error level
@@ -333,7 +334,7 @@ func (l *Logger) ErrorF(format string, a ...interface{}) {
 
 // ErrorF logs a message at Error level using the same syntax and options as fmt.Printf
 func (l *Logger) Errorf(format string, a ...interface{}) {
-	l.ErrorF(format, a...)
+	l.log_internal("ERROR", fmt.Sprintf(format, a...), 2)
 }
 
 // Warning logs a message at Warning level
@@ -348,7 +349,7 @@ func (l *Logger) WarningF(format string, a ...interface{}) {
 
 // WarningF logs a message at Warning level using the same syntax and options as fmt.Printf
 func (l *Logger) Warningf(format string, a ...interface{}) {
-	l.WarningF(format, a...)
+	l.log_internal("WARNING", fmt.Sprintf(format, a...), 2)
 }
 
 // Notice logs a message at Notice level
@@ -363,7 +364,7 @@ func (l *Logger) NoticeF(format string, a ...interface{}) {
 
 // NoticeF logs a message at Notice level using the same syntax and options as fmt.Printf
 func (l *Logger) Noticef(format string, a ...interface{}) {
-	l.NoticeF(format, a...)
+	l.log_internal("NOTICE", fmt.Sprintf(format, a...), 2)
 }
 
 // Info logs a message at Info level
@@ -378,7 +379,7 @@ func (l *Logger) InfoF(format string, a ...interface{}) {
 
 // InfoF logs a message at Info level using the same syntax and options as fmt.Printf
 func (l *Logger) Infof(format string, a ...interface{}) {
-	l.InfoF(format, a...)
+	l.log_internal("INFO", fmt.Sprintf(format, a...), 2)
 }
 
 // Debug logs a message at Debug level
@@ -393,7 +394,7 @@ func (l *Logger) DebugF(format string, a ...interface{}) {
 
 // DebugF logs a message at Debug level using the same syntax and options as fmt.Printf
 func (l *Logger) Debugf(format string, a ...interface{}) {
-	l.DebugF(format, a...)
+	l.log_internal("DEBUG", fmt.Sprintf(format, a...), 2)
 }
 
 // Prints this goroutine's execution stack as an error with an optional message at the begining

--- a/logger.go
+++ b/logger.go
@@ -117,7 +117,12 @@ func parseFormat(format string) (msgfmt, timefmt string) {
 						timefmt = arg
 					}
 					format = format[jdx+1:]
+				} else {
+					format = format[1:]
 				}
+			} else {
+				msgfmt += "%"
+				format = format[1:]
 			}
 		}
 		idx = strings.IndexRune(format, '%')

--- a/logger.go
+++ b/logger.go
@@ -47,10 +47,10 @@ const (
 // Worker class, Worker is a log object used to log messages and Color specifies
 // if colored output is to be produced
 type Worker struct {
-	Minion 			*log.Logger
-	Color  			int
-	format 			string
-	timeFormat 	string
+	Minion      *log.Logger
+	Color       int
+	format      string
+	timeFormat  string
 }
 
 // Info class, Contains all the info on what has to logged, time is the current time, Module is the specific module
@@ -83,13 +83,13 @@ func init() {
 // Returns a proper string to be outputted for a particular info
 func (r *Info) Output(format string) string {
 	msg := fmt.Sprintf(format,
-		r.Id, 				// %[1] // %{id}
-		r.Time, 			// %[2] // %{time[:fmt]}
-		r.Module, 		// %[3] // %{module}
-		r.Filename, 	// %[4] // %{filename}
-		r.Line, 			// %[5] // %{line}
-		r.Level, 			// %[6] // %{level}
-		r.Message,		// %[7] // %{message}
+		r.Id,         // %[1] // %{id}
+		r.Time,       // %[2] // %{time[:fmt]}
+		r.Module,     // %[3] // %{module}
+		r.Filename,   // %[4] // %{filename}
+		r.Line,       // %[5] // %{line}
+		r.Level,      // %[6] // %{level}
+		r.Message,    // %[7] // %{message}
 	)
 	// Ignore printf errors if len(args) > len(verbs)
 	if i := strings.LastIndex(msg, "%!(EXTRA"); i != -1 {
@@ -197,15 +197,15 @@ func initColors() {
 // Initializes the map of placeholders
 func initFormatPlaceholders() {
 	phfs = map[string]string {
-		"%{id}" 			: "%[1]d",
-		"%{time}" 		:	"%[2]s",
-		"%{module}" 	: "%[3]s",
+		"%{id}"       : "%[1]d",
+		"%{time}"     : "%[2]s",
+		"%{module}"   : "%[3]s",
 		"%{filename}" : "%[4]s",
-		"%{file}"			: "%[4]s",
-		"%{line}" 		: "%[5]d",
-		"%{level}"		: "%[6]s",
-		"%{lvl}"			: "%[6].3s",
-		"%{message}"	: "%[7]s",
+		"%{file}"     : "%[4]s",
+		"%{line}"     : "%[5]d",
+		"%{level}"    : "%[6]s",
+		"%{lvl}"      : "%[6].3s",
+		"%{message}"  : "%[7]s",
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -110,9 +110,22 @@ func parseFormat(format string) (msgfmt, timefmt string) {
 		format = format[idx:]
 		if len(format) > 2 {
 			if format[1] == '{' {
+				// end of curr verb pos
 				if jdx := strings.IndexRune(format, '}'); jdx != -1 {
+					// next verb pos
+					idx = strings.Index(format[1:], "%{")
+					// incorrect verb found ("...%{wefwef ...") but after
+					// this, new verb (maybe) exists ("...%{inv %{verb}...")
+					if idx != -1 && idx < jdx {
+						msgfmt += "%%"
+						format = format[1:]
+						continue
+					}
+					// get verb and arg
 					verb, arg := ph2verb(format[:jdx+1])
 					msgfmt += verb
+					// check if verb is time
+					// here you can handle args for other verbs
 					if verb == `%[2]s` /* %{time} */ {
 						timefmt = arg
 					}
@@ -121,7 +134,7 @@ func parseFormat(format string) (msgfmt, timefmt string) {
 					format = format[1:]
 				}
 			} else {
-				msgfmt += "%"
+				msgfmt += "%%"
 				format = format[1:]
 			}
 		}
@@ -204,7 +217,7 @@ func initFormatPlaceholders() {
 		"%{file}"     : "%[4]s",
 		"%{line}"     : "%[5]d",
 		"%{level}"    : "%[6]s",
-		"%{lvl}"      : "%[6].3s",
+		"%{lvl}"      : "%.3[6]s",
 		"%{message}"  : "%[7]s",
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -265,6 +265,12 @@ func (l *Logger) FatalF(format string, a ...interface{}) {
 	os.Exit(1)
 }
 
+// FatalF is just like func l.CriticalF logger except that it is followed by exit to program
+func (l *Logger) Fatalf(format string, a ...interface{}) {
+	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	os.Exit(1)
+}
+
 // Panic is just like func l.Critical except that it is followed by a call to panic
 func (l *Logger) Panic(message string) {
 	l.log_internal("CRITICAL", message, 2)
@@ -277,6 +283,11 @@ func (l *Logger) PanicF(format string, a ...interface{}) {
 	panic(fmt.Sprintf(format, a...))
 }
 
+// PanicF is just like func l.CriticalF except that it is followed by a call to panic
+func (l *Logger) Panicf(format string, a ...interface{}) {
+	l.PanicF(format, a...)
+}
+
 // Critical logs a message at a Critical Level
 func (l *Logger) Critical(message string) {
 	l.log_internal("CRITICAL", message, 2)
@@ -285,6 +296,11 @@ func (l *Logger) Critical(message string) {
 // CriticalF logs a message at Critical level using the same syntax and options as fmt.Printf
 func (l *Logger) CriticalF(format string, a ...interface{}) {
 	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+}
+
+// CriticalF logs a message at Critical level using the same syntax and options as fmt.Printf
+func (l *Logger) Criticalf(format string, a ...interface{}) {
+	l.CriticalF(format, a...)
 }
 
 // Error logs a message at Error level
@@ -297,6 +313,11 @@ func (l *Logger) ErrorF(format string, a ...interface{}) {
 	l.log_internal("ERROR", fmt.Sprintf(format, a...), 2)
 }
 
+// ErrorF logs a message at Error level using the same syntax and options as fmt.Printf
+func (l *Logger) Errorf(format string, a ...interface{}) {
+	l.ErrorF(format, a...)
+}
+
 // Warning logs a message at Warning level
 func (l *Logger) Warning(message string) {
 	l.log_internal("WARNING", message, 2)
@@ -305,6 +326,11 @@ func (l *Logger) Warning(message string) {
 // WarningF logs a message at Warning level using the same syntax and options as fmt.Printf
 func (l *Logger) WarningF(format string, a ...interface{}) {
 	l.log_internal("WARNING", fmt.Sprintf(format, a...), 2)
+}
+
+// WarningF logs a message at Warning level using the same syntax and options as fmt.Printf
+func (l *Logger) Warningf(format string, a ...interface{}) {
+	l.WarningF(format, a...)
 }
 
 // Notice logs a message at Notice level
@@ -317,6 +343,11 @@ func (l *Logger) NoticeF(format string, a ...interface{}) {
 	l.log_internal("NOTICE", fmt.Sprintf(format, a...), 2)
 }
 
+// NoticeF logs a message at Notice level using the same syntax and options as fmt.Printf
+func (l *Logger) Noticef(format string, a ...interface{}) {
+	l.NoticeF(format, a...)
+}
+
 // Info logs a message at Info level
 func (l *Logger) Info(message string) {
 	l.log_internal("INFO", message, 2)
@@ -327,6 +358,11 @@ func (l *Logger) InfoF(format string, a ...interface{}) {
 	l.log_internal("INFO", fmt.Sprintf(format, a...), 2)
 }
 
+// InfoF logs a message at Info level using the same syntax and options as fmt.Printf
+func (l *Logger) Infof(format string, a ...interface{}) {
+	l.InfoF(format, a...)
+}
+
 // Debug logs a message at Debug level
 func (l *Logger) Debug(message string) {
 	l.log_internal("DEBUG", message, 2)
@@ -335,6 +371,11 @@ func (l *Logger) Debug(message string) {
 // DebugF logs a message at Debug level using the same syntax and options as fmt.Printf
 func (l *Logger) DebugF(format string, a ...interface{}) {
 	l.log_internal("DEBUG", fmt.Sprintf(format, a...), 2)
+}
+
+// DebugF logs a message at Debug level using the same syntax and options as fmt.Printf
+func (l *Logger) Debugf(format string, a ...interface{}) {
+	l.DebugF(format, a...)
 }
 
 // Prints this goroutine's execution stack as an error with an optional message at the begining

--- a/logger_test.go
+++ b/logger_test.go
@@ -77,7 +77,7 @@ func TestColorString(t *testing.T) {
 }
 
 func TestInitColors(t *testing.T) {
-	initColors()
+	//initColors()
 	var tests = []struct {
 		level       string
 		color       int


### PR DESCRIPTION
Thanks for that simple and wonderful logger! 
But  I seen that module name isn't used and I decided to do it. I implemented this by adding ability to control of log messages format.
Also, I think that printf-like methods should have 'f' suffix, not 'F'. I added methods with these names. These methods are aliases to methods with suffix 'F'.