### PR TITLE
Add log level filter

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -179,8 +179,8 @@ func ph2verb(ph string) (verb string, arg string) {
 
 // Returns an instance of worker class, prefix is the string attached to every log,
 // flag determine the log params, color parameters verifies whether we need colored outputs or not
-func NewWorker(prefix string, flag int, color int, out io.Writer, level LogLevel) *Worker {
-	return &Worker{Minion: log.New(out, prefix, flag), Color: color, format: defFmt, timeFormat: defTimeFmt, level: level}
+func NewWorker(prefix string, flag int, color int, out io.Writer) *Worker {
+	return &Worker{Minion: log.New(out, prefix, flag), Color: color, format: defFmt, timeFormat: defTimeFmt}
 }
 
 func SetDefaultFormat(format string) {
@@ -193,6 +193,10 @@ func (w *Worker) SetFormat(format string) {
 
 func (l *Logger) SetFormat(format string) {
 	l.worker.SetFormat(format)
+}
+
+func (w *Worker) SetLogLevel(level LogLevel) {
+	w.level = level
 }
 
 func (l *Logger) SetLogLevel(level LogLevel) {
@@ -274,7 +278,8 @@ func New(args ...interface{}) (*Logger, error) {
 			panic("logger: Unknown argument")
 		}
 	}
-	newWorker := NewWorker("", 0, color, out, level)
+	newWorker := NewWorker("", 0, color, out)
+	newWorker.SetLogLevel(level)
 	return &Logger{Module: module, worker: newWorker}, nil
 }
 

--- a/logger.go
+++ b/logger.go
@@ -10,14 +10,14 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"time"
-	"strings"
 )
 
 var (
-	// Map for te various codes of colors
-	colors map[string]string
+	// Map for the various codes of colors
+	colors map[LogLevel]string
 
 	// Map from format's placeholders to printf verbs
 	phfs map[string]string
@@ -32,6 +32,9 @@ var (
 	defTimeFmt = "2006-01-02 15:04:05"
 )
 
+// LogLevel type
+type LogLevel int
+
 // Color numbers for stdout
 const (
 	Black = (iota + 30)
@@ -44,13 +47,24 @@ const (
 	White
 )
 
+// Log Level
+const (
+	CriticalLevel LogLevel = iota + 1
+	ErrorLevel
+	WarningLevel
+	NoticeLevel
+	DebugLevel
+	InfoLevel
+)
+
 // Worker class, Worker is a log object used to log messages and Color specifies
 // if colored output is to be produced
 type Worker struct {
-	Minion      *log.Logger
-	Color       int
-	format      string
-	timeFormat  string
+	Minion     *log.Logger
+	Color      int
+	format     string
+	timeFormat string
+	level      LogLevel
 }
 
 // Info class, Contains all the info on what has to logged, time is the current time, Module is the specific module
@@ -60,7 +74,7 @@ type Info struct {
 	Id       uint64
 	Time     string
 	Module   string
-	Level    string
+	Level    LogLevel
 	Line     int
 	Filename string
 	Message  string
@@ -83,13 +97,13 @@ func init() {
 // Returns a proper string to be outputted for a particular info
 func (r *Info) Output(format string) string {
 	msg := fmt.Sprintf(format,
-		r.Id,         // %[1] // %{id}
-		r.Time,       // %[2] // %{time[:fmt]}
-		r.Module,     // %[3] // %{module}
-		r.Filename,   // %[4] // %{filename}
-		r.Line,       // %[5] // %{line}
-		r.Level,      // %[6] // %{level}
-		r.Message,    // %[7] // %{message}
+		r.Id,               // %[1] // %{id}
+		r.Time,             // %[2] // %{time[:fmt]}
+		r.Module,           // %[3] // %{module}
+		r.Filename,         // %[4] // %{filename}
+		r.Line,             // %[5] // %{line}
+		r.logLevelString(), // %[6] // %{level}
+		r.Message,          // %[7] // %{message}
 	)
 	// Ignore printf errors if len(args) > len(verbs)
 	if i := strings.LastIndex(msg, "%!(EXTRA"); i != -1 {
@@ -148,21 +162,25 @@ func parseFormat(format string) (msgfmt, timefmt string) {
 // (now used only as time format)
 func ph2verb(ph string) (verb string, arg string) {
 	n := len(ph)
-	if n < 4 { return ``, `` }
-	if ph[0] != '%' || ph[1] != '{' || ph[n-1] != '}' { return ``, `` }
+	if n < 4 {
+		return ``, ``
+	}
+	if ph[0] != '%' || ph[1] != '{' || ph[n-1] != '}' {
+		return ``, ``
+	}
 	idx := strings.IndexRune(ph, ':')
 	if idx == -1 {
 		return phfs[ph], ``
 	}
-	verb = phfs[ ph[:idx] + "}" ]
-	arg = ph[idx+1:n-1]
+	verb = phfs[ph[:idx]+"}"]
+	arg = ph[idx+1 : n-1]
 	return
 }
 
 // Returns an instance of worker class, prefix is the string attached to every log,
 // flag determine the log params, color parameters verifies whether we need colored outputs or not
-func NewWorker(prefix string, flag int, color int, out io.Writer) *Worker {
-	return &Worker{Minion: log.New(out, prefix, flag), Color: color, format: defFmt, timeFormat: defTimeFmt}
+func NewWorker(prefix string, flag int, color int, out io.Writer, level LogLevel) *Worker {
+	return &Worker{Minion: log.New(out, prefix, flag), Color: color, format: defFmt, timeFormat: defTimeFmt, level: level}
 }
 
 func SetDefaultFormat(format string) {
@@ -177,8 +195,17 @@ func (l *Logger) SetFormat(format string) {
 	l.worker.SetFormat(format)
 }
 
+func (l *Logger) SetLogLevel(level LogLevel) {
+	l.worker.level = level
+}
+
 // Function of Worker class to log a string based on level
-func (w *Worker) Log(level string, calldepth int, info *Info) error {
+func (w *Worker) Log(level LogLevel, calldepth int, info *Info) error {
+
+	if w.level < level {
+		return nil
+	}
+
 	if w.Color != 0 {
 		buf := &bytes.Buffer{}
 		buf.Write([]byte(colors[level]))
@@ -197,28 +224,28 @@ func colorString(color int) string {
 
 // Initializes the map of colors
 func initColors() {
-	colors = map[string]string{
-		"CRITICAL": colorString(Magenta),
-		"ERROR":    colorString(Red),
-		"WARNING":  colorString(Yellow),
-		"NOTICE":   colorString(Green),
-		"DEBUG":    colorString(Cyan),
-		"INFO":     colorString(White),
+	colors = map[LogLevel]string{
+		CriticalLevel: colorString(Magenta),
+		ErrorLevel:    colorString(Red),
+		WarningLevel:  colorString(Yellow),
+		NoticeLevel:   colorString(Green),
+		DebugLevel:    colorString(Cyan),
+		InfoLevel:     colorString(White),
 	}
 }
 
 // Initializes the map of placeholders
 func initFormatPlaceholders() {
-	phfs = map[string]string {
-		"%{id}"       : "%[1]d",
-		"%{time}"     : "%[2]s",
-		"%{module}"   : "%[3]s",
-		"%{filename}" : "%[4]s",
-		"%{file}"     : "%[4]s",
-		"%{line}"     : "%[5]d",
-		"%{level}"    : "%[6]s",
-		"%{lvl}"      : "%.3[6]s",
-		"%{message}"  : "%[7]s",
+	phfs = map[string]string{
+		"%{id}":       "%[1]d",
+		"%{time}":     "%[2]s",
+		"%{module}":   "%[3]s",
+		"%{filename}": "%[4]s",
+		"%{file}":     "%[4]s",
+		"%{line}":     "%[5]d",
+		"%{level}":    "%[6]s",
+		"%{lvl}":      "%.3[6]s",
+		"%{message}":  "%[7]s",
 	}
 }
 
@@ -231,6 +258,7 @@ func New(args ...interface{}) (*Logger, error) {
 	var module string = "DEFAULT"
 	var color int = 1
 	var out io.Writer = os.Stderr
+	var level LogLevel = InfoLevel
 
 	for _, arg := range args {
 		switch t := arg.(type) {
@@ -240,21 +268,23 @@ func New(args ...interface{}) (*Logger, error) {
 			color = t
 		case io.Writer:
 			out = t
+		case LogLevel:
+			level = t
 		default:
 			panic("logger: Unknown argument")
 		}
 	}
-	newWorker := NewWorker("", 0, color, out)
+	newWorker := NewWorker("", 0, color, out, level)
 	return &Logger{Module: module, worker: newWorker}, nil
 }
 
 // The log commnand is the function available to user to log message, lvl specifies
 // the degree of the messagethe user wants to log, message is the info user wants to log
-func (l *Logger) Log(lvl string, message string) {
+func (l *Logger) Log(lvl LogLevel, message string) {
 	l.log_internal(lvl, message, 2)
 }
 
-func (l *Logger) log_internal(lvl string, message string, pos int) {
+func (l *Logger) log_internal(lvl LogLevel, message string, pos int) {
 	//var formatString string = "#%d %s [%s] %s:%d ▶ %.3s %s"
 	_, filename, line, _ := runtime.Caller(pos)
 	filename = path.Base(filename)
@@ -273,128 +303,128 @@ func (l *Logger) log_internal(lvl string, message string, pos int) {
 
 // Fatal is just like func l.Critical logger except that it is followed by exit to program
 func (l *Logger) Fatal(message string) {
-	l.log_internal("CRITICAL", message, 2)
+	l.log_internal(CriticalLevel, message, 2)
 	os.Exit(1)
 }
 
 // FatalF is just like func l.CriticalF logger except that it is followed by exit to program
 func (l *Logger) FatalF(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 	os.Exit(1)
 }
 
 // FatalF is just like func l.CriticalF logger except that it is followed by exit to program
 func (l *Logger) Fatalf(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 	os.Exit(1)
 }
 
 // Panic is just like func l.Critical except that it is followed by a call to panic
 func (l *Logger) Panic(message string) {
-	l.log_internal("CRITICAL", message, 2)
+	l.log_internal(CriticalLevel, message, 2)
 	panic(message)
 }
 
 // PanicF is just like func l.CriticalF except that it is followed by a call to panic
 func (l *Logger) PanicF(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 	panic(fmt.Sprintf(format, a...))
 }
 
 // PanicF is just like func l.CriticalF except that it is followed by a call to panic
 func (l *Logger) Panicf(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 	panic(fmt.Sprintf(format, a...))
 }
 
 // Critical logs a message at a Critical Level
 func (l *Logger) Critical(message string) {
-	l.log_internal("CRITICAL", message, 2)
+	l.log_internal(CriticalLevel, message, 2)
 }
 
 // CriticalF logs a message at Critical level using the same syntax and options as fmt.Printf
 func (l *Logger) CriticalF(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // CriticalF logs a message at Critical level using the same syntax and options as fmt.Printf
 func (l *Logger) Criticalf(format string, a ...interface{}) {
-	l.log_internal("CRITICAL", fmt.Sprintf(format, a...), 2)
+	l.log_internal(CriticalLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Error logs a message at Error level
 func (l *Logger) Error(message string) {
-	l.log_internal("ERROR", message, 2)
+	l.log_internal(ErrorLevel, message, 2)
 }
 
 // ErrorF logs a message at Error level using the same syntax and options as fmt.Printf
 func (l *Logger) ErrorF(format string, a ...interface{}) {
-	l.log_internal("ERROR", fmt.Sprintf(format, a...), 2)
+	l.log_internal(ErrorLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // ErrorF logs a message at Error level using the same syntax and options as fmt.Printf
 func (l *Logger) Errorf(format string, a ...interface{}) {
-	l.log_internal("ERROR", fmt.Sprintf(format, a...), 2)
+	l.log_internal(ErrorLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Warning logs a message at Warning level
 func (l *Logger) Warning(message string) {
-	l.log_internal("WARNING", message, 2)
+	l.log_internal(WarningLevel, message, 2)
 }
 
 // WarningF logs a message at Warning level using the same syntax and options as fmt.Printf
 func (l *Logger) WarningF(format string, a ...interface{}) {
-	l.log_internal("WARNING", fmt.Sprintf(format, a...), 2)
+	l.log_internal(WarningLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // WarningF logs a message at Warning level using the same syntax and options as fmt.Printf
 func (l *Logger) Warningf(format string, a ...interface{}) {
-	l.log_internal("WARNING", fmt.Sprintf(format, a...), 2)
+	l.log_internal(WarningLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Notice logs a message at Notice level
 func (l *Logger) Notice(message string) {
-	l.log_internal("NOTICE", message, 2)
+	l.log_internal(NoticeLevel, message, 2)
 }
 
 // NoticeF logs a message at Notice level using the same syntax and options as fmt.Printf
 func (l *Logger) NoticeF(format string, a ...interface{}) {
-	l.log_internal("NOTICE", fmt.Sprintf(format, a...), 2)
+	l.log_internal(NoticeLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // NoticeF logs a message at Notice level using the same syntax and options as fmt.Printf
 func (l *Logger) Noticef(format string, a ...interface{}) {
-	l.log_internal("NOTICE", fmt.Sprintf(format, a...), 2)
+	l.log_internal(NoticeLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Info logs a message at Info level
 func (l *Logger) Info(message string) {
-	l.log_internal("INFO", message, 2)
+	l.log_internal(InfoLevel, message, 2)
 }
 
 // InfoF logs a message at Info level using the same syntax and options as fmt.Printf
 func (l *Logger) InfoF(format string, a ...interface{}) {
-	l.log_internal("INFO", fmt.Sprintf(format, a...), 2)
+	l.log_internal(InfoLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // InfoF logs a message at Info level using the same syntax and options as fmt.Printf
 func (l *Logger) Infof(format string, a ...interface{}) {
-	l.log_internal("INFO", fmt.Sprintf(format, a...), 2)
+	l.log_internal(InfoLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Debug logs a message at Debug level
 func (l *Logger) Debug(message string) {
-	l.log_internal("DEBUG", message, 2)
+	l.log_internal(DebugLevel, message, 2)
 }
 
 // DebugF logs a message at Debug level using the same syntax and options as fmt.Printf
 func (l *Logger) DebugF(format string, a ...interface{}) {
-	l.log_internal("DEBUG", fmt.Sprintf(format, a...), 2)
+	l.log_internal(DebugLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // DebugF logs a message at Debug level using the same syntax and options as fmt.Printf
 func (l *Logger) Debugf(format string, a ...interface{}) {
-	l.log_internal("DEBUG", fmt.Sprintf(format, a...), 2)
+	l.log_internal(DebugLevel, fmt.Sprintf(format, a...), 2)
 }
 
 // Prints this goroutine's execution stack as an error with an optional message at the begining
@@ -403,7 +433,7 @@ func (l *Logger) StackAsError(message string) {
 		message = "Stack info"
 	}
 	message += "\n"
-	l.log_internal("ERROR", message+Stack(), 2)
+	l.log_internal(ErrorLevel, message+Stack(), 2)
 }
 
 // Prints this goroutine's execution stack as critical with an optional message at the begining
@@ -412,7 +442,7 @@ func (l *Logger) StackAsCritical(message string) {
 		message = "Stack info"
 	}
 	message += "\n"
-	l.log_internal("CRITICAL", message+Stack(), 2)
+	l.log_internal(CriticalLevel, message+Stack(), 2)
 }
 
 // Returns a string with the execution stack for this goroutine
@@ -420,4 +450,17 @@ func Stack() string {
 	buf := make([]byte, 1000000)
 	runtime.Stack(buf, false)
 	return string(buf)
+}
+
+// Returns the loglevel as string
+func (info *Info) logLevelString() string {
+	logLevels := [...]string{
+		"CRITICAL",
+		"ERROR",
+		"WARNING",
+		"NOTICE",
+		"DEBUG",
+		"INFO",
+	}
+	return logLevels[info.Level-1]
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -128,7 +128,7 @@ func TestInitColors(t *testing.T) {
 }
 
 func TestNewWorker(t *testing.T) {
-	var worker *Worker = NewWorker("", 0, 1, os.Stderr, InfoLevel)
+	var worker *Worker = NewWorker("", 0, 1, os.Stderr)
 	if worker.Minion == nil {
 		t.Errorf("Minion was not established")
 	}
@@ -136,7 +136,7 @@ func TestNewWorker(t *testing.T) {
 
 func BenchmarkNewWorker(b *testing.B) {
 	for n := 0; n <= b.N; n++ {
-		worker := NewWorker("", 0, 1, os.Stderr, InfoLevel)
+		worker := NewWorker("", 0, 1, os.Stderr)
 		if worker == nil {
 			panic("Failed to initiate worker")
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,12 +1,13 @@
 package logger
 
 import (
-	"os"
-	"testing"
 	"bytes"
-	"time"
 	"fmt"
 	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
 )
 
 func BenchmarkLoggerLog(b *testing.B) {
@@ -17,31 +18,31 @@ func BenchmarkLoggerLog(b *testing.B) {
 	}
 
 	var tests = []struct {
-		level   string
+		level   LogLevel
 		message string
 	}{
 		{
-			"CRITICAL",
+			CriticalLevel,
 			"Critical Logging",
 		},
 		{
-			"INFO",
+			InfoLevel,
 			"Info Logging",
 		},
 		{
-			"DEBUG",
+			DebugLevel,
 			"Debug logging",
 		},
 		{
-			"WARNING",
+			WarningLevel,
 			"Warning logging",
 		},
 		{
-			"NOTICE",
+			NoticeLevel,
 			"Notice Logging",
 		},
 		{
-			"ERROR",
+			ErrorLevel,
 			"Error logging",
 		},
 	}
@@ -83,37 +84,37 @@ func TestColorString(t *testing.T) {
 func TestInitColors(t *testing.T) {
 	//initColors()
 	var tests = []struct {
-		level       string
+		level       LogLevel
 		color       int
 		colorString string
 	}{
 		{
-			"CRITICAL",
+			CriticalLevel,
 			Magenta,
 			"\033[35m",
 		},
 		{
-			"ERROR",
+			ErrorLevel,
 			Red,
 			"\033[31m",
 		},
 		{
-			"WARNING",
+			WarningLevel,
 			Yellow,
 			"\033[33m",
 		},
 		{
-			"NOTICE",
+			NoticeLevel,
 			Green,
 			"\033[32m",
 		},
 		{
-			"DEBUG",
+			DebugLevel,
 			Cyan,
 			"\033[36m",
 		},
 		{
-			"INFO",
+			InfoLevel,
 			White,
 			"\033[37m",
 		},
@@ -127,7 +128,7 @@ func TestInitColors(t *testing.T) {
 }
 
 func TestNewWorker(t *testing.T) {
-	var worker *Worker = NewWorker("", 0, 1, os.Stderr)
+	var worker *Worker = NewWorker("", 0, 1, os.Stderr, InfoLevel)
 	if worker.Minion == nil {
 		t.Errorf("Minion was not established")
 	}
@@ -135,7 +136,7 @@ func TestNewWorker(t *testing.T) {
 
 func BenchmarkNewWorker(b *testing.B) {
 	for n := 0; n <= b.N; n++ {
-		worker := NewWorker("", 0, 1, os.Stderr)
+		worker := NewWorker("", 0, 1, os.Stderr, InfoLevel)
 		if worker == nil {
 			panic("Failed to initiate worker")
 		}
@@ -157,28 +158,28 @@ func TestLogger_SetFormat(t *testing.T) {
 	}
 	format :=
 		"text123 %{id} " + // text and digits before id
-		"!@#$% %{time:Monday, 2006 Jan 01, 15:04:05} " + // symbols before time with spec format
-		"a{b %{module} " + // brace with text that should be just text before verb
-		"a}b %{filename} " + // brace with text that should be just text before verb
-		"%% %{file} " + // percent symbols before verb
-		"%{%{line} " + // percent symbol with brace before verb w/o space
-		"%{nonex_verb} %{lvl} " + // nonexistent verb berfore real verb
-		"%{incorr_verb %{level} " + // incorrect verb before real verb
-		"%{} [%{message}]" // empty verb before message in sq brackets
+			"!@#$% %{time:Monday, 2006 Jan 01, 15:04:05} " + // symbols before time with spec format
+			"a{b %{module} " + // brace with text that should be just text before verb
+			"a}b %{filename} " + // brace with text that should be just text before verb
+			"%% %{file} " + // percent symbols before verb
+			"%{%{line} " + // percent symbol with brace before verb w/o space
+			"%{nonex_verb} %{lvl} " + // nonexistent verb berfore real verb
+			"%{incorr_verb %{level} " + // incorrect verb before real verb
+			"%{} [%{message}]" // empty verb before message in sq brackets
 	buf.Reset()
 	log.SetFormat(format)
 	log.Error("This is Error!")
 	now := time.Now()
 	want = fmt.Sprintf(
-		"text123 2 " +
-		"!@#$%% %s " +
-		"a{b pkgname " +
-		"a}b logger_test.go " +
-		"%%%% logger_test.go " + // it's printf, escaping %, don't forget
-		"%%{170 " +
-		" ERR " +
-		"%%{incorr_verb ERROR " +
-		" [This is Error!]\n",
+		"text123 2 "+
+			"!@#$%% %s "+
+			"a{b pkgname "+
+			"a}b logger_test.go "+
+			"%%%% logger_test.go "+ // it's printf, escaping %, don't forget
+			"%%{170 "+
+			" ERR "+
+			"%%{incorr_verb ERROR "+
+			" [This is Error!]\n",
 		now.Format("Monday, 2006 Jan 01, 15:04:05"),
 	)
 	have = buf.String()
@@ -212,5 +213,63 @@ func TestSetDefaultFormat(t *testing.T) {
 	have := buf.String()
 	if want != have {
 		t.Errorf("\nWant: %sHave: %s", want, have)
+	}
+}
+
+func TestLogLevel(t *testing.T) {
+
+	var tests = []struct {
+		level   LogLevel
+		message string
+	}{
+		{
+			CriticalLevel,
+			"Critical Logging",
+		},
+		{
+			ErrorLevel,
+			"Error logging",
+		},
+
+		{
+			WarningLevel,
+			"Warning logging",
+		},
+		{
+			NoticeLevel,
+			"Notice Logging",
+		},
+		{
+			DebugLevel,
+			"Debug logging",
+		},
+		{
+			InfoLevel,
+			"Info Logging",
+		},
+	}
+
+	var buf bytes.Buffer
+	log, err := New("pkgname", 0, &buf)
+	if err != nil {
+		panic(err)
+	}
+
+	for i, test := range tests {
+		log.SetLogLevel(test.level)
+
+		log.Critical("Log Critical")
+		log.Error("Log Error")
+		log.Warning("Log Warning")
+		log.Notice("Log Notice")
+		log.Debug("Log Debug")
+		log.Info("Log Info")
+
+		// Count output lines from logger
+		count := strings.Count(buf.String(), "\n")
+		if i+1 != count {
+			t.Error()
+		}
+		buf.Reset()
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -151,7 +151,7 @@ func TestLogger_SetFormat(t *testing.T) {
 	}
 	log.Debug("Test")
 	want := time.Now().Format("2006-01-02 15:04:05")
-	want = fmt.Sprintf("#1 %s logger_test.go:151 ▶ DEB Test\n", want)
+	want = fmt.Sprintf("#1 %s logger_test.go:152 ▶ DEB Test\n", want)
 	have := buf.String()
 	if have != want {
 		t.Errorf("\nWant: %sHave: %s", want, have)
@@ -176,7 +176,7 @@ func TestLogger_SetFormat(t *testing.T) {
 			"a{b pkgname "+
 			"a}b logger_test.go "+
 			"%%%% logger_test.go "+ // it's printf, escaping %, don't forget
-			"%%{170 "+
+			"%%{171 "+
 			" ERR "+
 			"%%{incorr_verb ERROR "+
 			" [This is Error!]\n",


### PR DESCRIPTION
Adds the possibility to define the log level from which log messages should be outputted.
 e.g. if the log level is set to ErrorLevel only critical and error log messages are processed. 

Closes issues #14 and #4