### PR TITLE
Fixing log level order

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -53,8 +53,8 @@ const (
 	ErrorLevel
 	WarningLevel
 	NoticeLevel
-	DebugLevel
 	InfoLevel
+	DebugLevel
 )
 
 // Worker class, Worker is a log object used to log messages and Color specifies


### PR DESCRIPTION
Log level order was incorrect: debug was before info.
This manifests in not having Info log not displayed when setting log level to debug.